### PR TITLE
chore: Expose components of `jmt` and update methods for `lr_trie`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 
 [workspace.dependencies]
 serde_hash = { path = "serde_hash" }
-jmt = { path = "jmt" }
+jmt = { path = "jmt", features = ["mocks"] }
 left-right = "0.11.5"
 keccak-hash = "0.9"
 fixed-hash = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,19 @@ keccak-hash = { workspace = true }
 parking_lot = { workspace = true }
 hashbrown = { workspace = true }
 fixed-hash = { workspace = true }
+serde_hash = { workspace = true }
+jmt = { workspace = true }
 
 [workspace]
 members = [
     "jmt",
-    "pmt"
+    "pmt",
+    "serde_hash",
 ]
 
 [workspace.dependencies]
+serde_hash = { path = "serde_hash" }
+jmt = { path = "jmt" }
 left-right = "0.11.5"
 keccak-hash = "0.9"
 fixed-hash = "0.7.0"

--- a/jmt/Cargo.toml
+++ b/jmt/Cargo.toml
@@ -19,6 +19,7 @@ mocks = ["dep:parking_lot"]
 std = ["dep:thiserror"]
 
 [dependencies]
+serde_hash = { workspace = true }
 anyhow = { workspace = true }
 borsh = { workspace = true }
 hashbrown = { workspace = true }
@@ -26,7 +27,6 @@ itertools = { workspace = true }
 mirai-annotations = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
-pmt = { path = "../pmt" }
 serde = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }

--- a/jmt/src/db.rs
+++ b/jmt/src/db.rs
@@ -3,6 +3,9 @@ use crate::{
     KeyHash, OwnedValue, Version,
 };
 use anyhow::Result;
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
+#[cfg(feature = "std")]
 use std::collections::HashMap;
 
 /// Defines the interaction between a database and the node versioning strategy

--- a/jmt/src/db.rs
+++ b/jmt/src/db.rs
@@ -113,6 +113,19 @@ pub trait VersionedDatabase: Send + Sync + Clone + Default + std::fmt::Debug {
             .count()
     }
 
+    /// Get the latest [`Version`] of the tree stored in the value history.
+    fn version(&self) -> Version {
+        let mut latest: u64 = 0;
+        for values in self.value_history().values() {
+            for (ver, _) in values.iter() {
+                if ver > &latest {
+                    latest = *ver;
+                }
+            }
+        }
+        latest
+    }
+
     /// Replaces `Database::values()`. Returns a clone of the nodes HashMap which
     /// has a `.values()` method returning `Values<NodeKey, Node>`
     /// for iteration over `jmt::VersionedDatabase`.
@@ -144,7 +157,7 @@ pub trait VersionedDatabase: Send + Sync + Clone + Default + std::fmt::Debug {
     fn value_history(&self) -> HashMap<KeyHash, Vec<(Version, Option<OwnedValue>)>>;
 
     /// Returns true if there are no nodes with `OwnedValue`s for the latest
-    /// `Version` in `Database::value_history()`
+    /// `Version` in `VersionedDatabase::value_history()`
     fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/jmt/src/iterator.rs
+++ b/jmt/src/iterator.rs
@@ -11,6 +11,7 @@ use alloc::{sync::Arc, vec::Vec};
 use anyhow::{bail, ensure, format_err, Result};
 
 use crate::{
+    db::VersionedDatabase,
     node_type::{Child, InternalNode, Node, NodeKey},
     storage::TreeReader,
     types::{
@@ -98,7 +99,7 @@ impl NodeVisitInfo {
 /// key-value pairs in this version of the tree, starting from the smallest key
 /// that is greater or equal to the given key, by performing a depth first
 /// traversal on the tree.
-pub struct JellyfishMerkleIterator<R> {
+pub struct JellyfishMerkleIterator<R: TreeReader + VersionedDatabase> {
     /// The storage engine from which we can read nodes using node keys.
     reader: Arc<R>,
 
@@ -116,7 +117,7 @@ pub struct JellyfishMerkleIterator<R> {
 
 impl<R> JellyfishMerkleIterator<R>
 where
-    R: TreeReader,
+    R: TreeReader + VersionedDatabase,
 {
     /// Constructs a new iterator. This puts the internal state in the correct position, so the
     /// following `next` call will yield the smallest key that is greater or equal to
@@ -275,7 +276,7 @@ where
 
 impl<R> Iterator for JellyfishMerkleIterator<R>
 where
-    R: TreeReader,
+    R: TreeReader + VersionedDatabase,
 {
     type Item = Result<(KeyHash, OwnedValue)>;
 

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -96,6 +96,7 @@ pub mod restore;
 
 use bytes32ext::Bytes32Ext;
 pub use iterator::JellyfishMerkleIterator;
+pub use sha2::Sha256;
 #[cfg(feature = "ics23")]
 pub use tree::ics23_impl::ics23_spec;
 pub use tree::{H256Jmt, JellyfishMerkleTree, Sha256Jmt};

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -276,7 +276,7 @@ impl<'a> core::fmt::Debug for EscapedByteSlice<'a> {
 
 /// A minimal trait representing a hash function. We implement our own
 /// rather than relying on `Digest` for broader compatibility.
-pub trait SimpleHasher: Sized + Clone {
+pub trait SimpleHasher: Sized + Clone + Debug {
     /// Creates a new hasher with default state.
     fn new() -> Self;
     /// Ingests the provided data, updating the hasher's state.
@@ -318,7 +318,7 @@ impl<H: SimpleHasher> Default for PhantomHasher<H> {
     }
 }
 
-impl<T: Digest + Clone> SimpleHasher for T
+impl<T: Digest + Clone + Debug> SimpleHasher for T
 where
     [u8; 32]: From<GenericArray<u8, <T as OutputSizeUser>::OutputSize>>,
 {

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -81,13 +81,13 @@ use sha2::Digest;
 use thiserror::Error;
 
 mod bytes32ext;
-mod db;
+pub mod db;
 mod iterator;
 mod node_type;
 mod reader;
 mod tree;
 mod tree_cache;
-mod trie;
+pub mod trie;
 mod types;
 mod writer;
 

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -99,7 +99,7 @@ use bytes32ext::Bytes32Ext;
 pub use iterator::JellyfishMerkleIterator;
 #[cfg(feature = "ics23")]
 pub use tree::ics23_impl::ics23_spec;
-pub use tree::{JellyfishMerkleTree, Sha256Jmt};
+pub use tree::{H256Jmt, JellyfishMerkleTree, Sha256Jmt};
 use types::nibble::ROOT_NIBBLE_HEIGHT;
 pub use types::proof;
 pub use types::Version;

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -84,7 +84,7 @@ mod bytes32ext;
 pub mod db;
 mod iterator;
 mod node_type;
-mod reader;
+pub mod reader;
 mod tree;
 mod tree_cache;
 pub mod trie;

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 #![cfg_attr(not(feature = "std"), no_std)]
-#![forbid(unsafe_code)]
 
 //! This module implements [`JellyfishMerkleTree`] backed by storage module. The tree itself doesn't
 //! persist anything, but realizes the logic of R/W only. The write path will produce all the
@@ -277,7 +276,7 @@ impl<'a> core::fmt::Debug for EscapedByteSlice<'a> {
 
 /// A minimal trait representing a hash function. We implement our own
 /// rather than relying on `Digest` for broader compatibility.
-pub trait SimpleHasher: Sized {
+pub trait SimpleHasher: Sized + Clone {
     /// Creates a new hasher with default state.
     fn new() -> Self;
     /// Ingests the provided data, updating the hasher's state.
@@ -319,7 +318,7 @@ impl<H: SimpleHasher> Default for PhantomHasher<H> {
     }
 }
 
-impl<T: Digest> SimpleHasher for T
+impl<T: Digest + Clone> SimpleHasher for T
 where
     [u8; 32]: From<GenericArray<u8, <T as OutputSizeUser>::OutputSize>>,
 {

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -88,7 +88,7 @@ mod tree;
 mod tree_cache;
 pub mod trie;
 mod types;
-mod writer;
+pub mod writer;
 
 #[cfg(any(test, feature = "mocks"))]
 pub mod mock;

--- a/jmt/src/reader.rs
+++ b/jmt/src/reader.rs
@@ -7,7 +7,7 @@ use crate::{KeyHash, OwnedValue, Version};
 /// Defines the interface between a
 /// [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)
 /// and underlying storage holding nodes.
-pub trait TreeReader {
+pub trait TreeReader: Clone + Default {
     /// Gets node given a node key. Returns error if the node does not exist.
     fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
         self.get_node_option(node_key)?

--- a/jmt/src/restore.rs
+++ b/jmt/src/restore.rs
@@ -184,8 +184,9 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
                 // to recover the partial nodes to the state right before the crash.
                 //
                 // Use of unsafe block to retrieve inner value of the TreeReader.
-                // Necessary to implement Clone.
-                let raw_tree_reader = Arc::into_raw(tree_reader);
+                // Necessary to implement Clone and other traits for TreeReader.
+                // Does not affect the state of the Arc.
+                let raw_tree_reader = Arc::as_ptr(&tree_reader);
                 let recovery_tree = unsafe { &*raw_tree_reader };
                 (
                     Self::recover_partial_nodes(recovery_tree.clone(), version, node_key)?,

--- a/jmt/src/restore.rs
+++ b/jmt/src/restore.rs
@@ -182,8 +182,13 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
                 // TODO: confirm rightmost leaf is at the desired version
                 // If the system crashed in the middle of the previous restoration attempt, we need
                 // to recover the partial nodes to the state right before the crash.
+                //
+                // Use of unsafe block to retrieve inner value of the TreeReader.
+                // Necessary to implement Clone.
+                let raw_tree_reader = Arc::into_raw(tree_reader);
+                let recovery_tree = unsafe { &*raw_tree_reader };
                 (
-                    Self::recover_partial_nodes(tree_reader.as_ref(), version, node_key)?,
+                    Self::recover_partial_nodes(recovery_tree.clone(), version, node_key)?,
                     Some(leaf_node),
                 )
             } else {
@@ -227,8 +232,8 @@ impl<H: SimpleHasher> JellyfishMerkleRestore<H> {
 
     /// Recovers partial nodes from storage. We do this by looking at all the ancestors of the
     /// rightmost leaf. The ones do not exist in storage are the partial nodes.
-    fn recover_partial_nodes(
-        store: &dyn TreeReader,
+    fn recover_partial_nodes<R: TreeReader>(
+        store: R,
         version: Version,
         rightmost_leaf_node_key: NodeKey,
     ) -> Result<Vec<InternalInfo>> {

--- a/jmt/src/tests/restore.rs
+++ b/jmt/src/tests/restore.rs
@@ -41,7 +41,7 @@ proptest! {
                 .into_iter()
                 .collect()
         );
-        let tree = Sha256Jmt::new(&db);
+        let tree = Sha256Jmt::new(db);
         let expected_root_hash = tree.get_root_hash(version).unwrap();
         let batch1: Vec<_> = all.clone().into_iter().take(batch1_size).collect();
 
@@ -92,7 +92,7 @@ proptest! {
             restore.finish().unwrap();
         }
 
-        assert_success(&restore_db, expected_root_hash, &all, version);
+        assert_success(restore_db, expected_root_hash, &all, version);
     }
 
     #[test]
@@ -109,7 +109,7 @@ proptest! {
 }
 
 fn assert_success(
-    db: &MockTreeStore,
+    db: Arc<MockTreeStore>,
     expected_root_hash: RootHash,
     btree: &BTreeMap<KeyHash, OwnedValue>,
     version: Version,
@@ -130,7 +130,7 @@ fn restore_without_interruption(
     try_resume: bool,
 ) {
     let (db, source_version) = init_mock_db(&btree.clone().into_iter().collect());
-    let tree = Sha256Jmt::new(&db);
+    let tree = Sha256Jmt::new(db);
     let expected_root_hash = tree.get_root_hash(source_version).unwrap();
 
     let mut restore = if try_resume {
@@ -158,5 +158,5 @@ fn restore_without_interruption(
     }
     Box::new(restore).finish().unwrap();
 
-    assert_success(target_db, expected_root_hash, btree, target_version);
+    assert_success(target_db.clone(), expected_root_hash, btree, target_version);
 }

--- a/jmt/src/tests/tree_cache.rs
+++ b/jmt/src/tests/tree_cache.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::sync::Arc;
 use rand::{rngs::OsRng, Rng};
 use sha2::Sha256;
 
@@ -25,7 +26,7 @@ fn random_leaf_with_key(next_version: Version) -> (LeafNode, OwnedValue, NodeKey
 #[test]
 fn test_get_node() {
     let next_version = 0;
-    let db = MockTreeStore::default();
+    let db = Arc::new(MockTreeStore::default());
     let cache = TreeCache::new(&db, next_version).unwrap();
 
     let (node, value, node_key) = random_leaf_with_key(next_version);
@@ -37,7 +38,7 @@ fn test_get_node() {
 #[test]
 fn test_root_node() {
     let next_version = 0;
-    let db = MockTreeStore::default();
+    let db = Arc::new(MockTreeStore::default());
     let mut cache = TreeCache::new(&db, next_version).unwrap();
     assert_eq!(*cache.get_root_node_key(), NodeKey::new_empty_path(0));
 
@@ -51,7 +52,7 @@ fn test_root_node() {
 #[test]
 fn test_pre_genesis() {
     let next_version = 0;
-    let db = MockTreeStore::default();
+    let db = Arc::new(MockTreeStore::default());
     let pre_genesis_root_key = NodeKey::new_empty_path(PRE_GENESIS_VERSION);
     let (pre_genesis_only_node, pre_genesis_only_value, _) =
         random_leaf_with_key(PRE_GENESIS_VERSION);
@@ -69,7 +70,7 @@ fn test_pre_genesis() {
 #[test]
 fn test_freeze_with_delete() {
     let next_version = 0;
-    let db = MockTreeStore::default();
+    let db = Arc::new(MockTreeStore::default());
     let mut cache = TreeCache::new(&db, next_version).unwrap();
 
     assert_eq!(*cache.get_root_node_key(), NodeKey::new_empty_path(0));

--- a/jmt/src/tests/vectors.rs
+++ b/jmt/src/tests/vectors.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 
@@ -33,7 +33,7 @@ fn test_with_vectors() {
     let test_file: TestVectorWrapper =
         serde_json::from_str(test_vectors).expect("test vectors must be valid json");
 
-    let store = &MockTreeStore::default();
+    let store = Arc::new(MockTreeStore::default());
 
     let jmt = Sha256Jmt::new(store);
     for vector in test_file.vectors {

--- a/jmt/src/tests/versioned_db.rs
+++ b/jmt/src/tests/versioned_db.rs
@@ -1,10 +1,11 @@
-use crate::{db::VersionedDatabase, mock::MockTreeStore, KeyHash, Sha256Jmt};
+use crate::{db::VersionedDatabase, mock::MockTreeStore, trie::VersionedTrie, KeyHash, Sha256Jmt};
+use alloc::sync::Arc;
 use sha2::Sha256;
 
 #[test]
 fn test_versioned_db_len() {
-    let db = MockTreeStore::default();
-    let tree = Sha256Jmt::new(&db);
+    let db = Arc::new(MockTreeStore::default());
+    let tree = Sha256Jmt::new(db);
 
     // add old set
     let key = b"old_vers";
@@ -13,8 +14,8 @@ fn test_versioned_db_len() {
         .put_value_set(vec![(KeyHash::with::<Sha256>(key), Some(value.clone()))], 0)
         .unwrap();
 
-    db.write_tree_update_batch(batch).unwrap();
-    assert_eq!(db.len(), 1);
+    tree.reader().write_tree_update_batch(batch).unwrap();
+    assert_eq!(tree.reader().len(), 1);
 
     // add new set
     let key = b"new_vers";
@@ -23,8 +24,8 @@ fn test_versioned_db_len() {
         .put_value_set(vec![(KeyHash::with::<Sha256>(key), Some(value.clone()))], 1)
         .unwrap();
 
-    db.write_tree_update_batch(batch).unwrap();
-    assert_eq!(db.len(), 2);
+    tree.reader().write_tree_update_batch(batch).unwrap();
+    assert_eq!(tree.reader().len(), 2);
 
     // remove old set
     let key = b"old_vers";
@@ -32,14 +33,14 @@ fn test_versioned_db_len() {
         .put_value_set(vec![(KeyHash::with::<Sha256>(key), None)], 2)
         .unwrap();
 
-    db.write_tree_update_batch(batch).unwrap();
-    assert_eq!(db.len(), 1);
+    tree.reader().write_tree_update_batch(batch).unwrap();
+    assert_eq!(tree.reader().len(), 1);
 }
 
 #[test]
 fn test_versioned_db_is_empty() {
-    let db = MockTreeStore::default();
-    let tree = Sha256Jmt::new(&db);
+    let db = Arc::new(MockTreeStore::default());
+    let tree = Sha256Jmt::new(db);
 
     // add old set
     let key = b"old_vers";
@@ -48,8 +49,8 @@ fn test_versioned_db_is_empty() {
         .put_value_set(vec![(KeyHash::with::<Sha256>(key), Some(value.clone()))], 0)
         .unwrap();
 
-    db.write_tree_update_batch(batch).unwrap();
-    assert_eq!(db.len(), 1);
+    tree.reader().write_tree_update_batch(batch).unwrap();
+    assert_eq!(tree.reader().len(), 1);
 
     // remove old set
     let key = b"old_vers";
@@ -57,6 +58,6 @@ fn test_versioned_db_is_empty() {
         .put_value_set(vec![(KeyHash::with::<Sha256>(key), None)], 2)
         .unwrap();
 
-    db.write_tree_update_batch(batch).unwrap();
-    assert!(db.is_empty());
+    tree.reader().write_tree_update_batch(batch).unwrap();
+    assert!(tree.reader().is_empty());
 }

--- a/jmt/src/tree.rs
+++ b/jmt/src/tree.rs
@@ -37,6 +37,7 @@ pub type H256Jmt<'a, R> = JellyfishMerkleTree<'a, R, H256>;
 
 /// A Jellyfish Merkle tree data structure, parameterized by a [`TreeReader`] `R`
 /// and a [`SimpleHasher`] `H`. See [`crate`] for description.
+#[derive(Debug, Clone)]
 pub struct JellyfishMerkleTree<'a, R: TreeReader + VersionedDatabase, H: SimpleHasher> {
     reader: &'a R,
     leaf_count_migration: bool,

--- a/jmt/src/tree.rs
+++ b/jmt/src/tree.rs
@@ -48,7 +48,7 @@ pub struct JellyfishMerkleTree<'a, R: TreeReader + VersionedDatabase, H: SimpleH
 #[cfg(feature = "ics23")]
 pub mod ics23_impl;
 
-impl<'a, R, H> VersionedTrie<R, H> for JellyfishMerkleTree<'a, R, H>
+impl<'a, R, H> VersionedTrie<'a, R, H> for JellyfishMerkleTree<'a, R, H>
 where
     R: TreeReader + VersionedDatabase,
     H: SimpleHasher,
@@ -86,6 +86,10 @@ where
 
     fn version(&self) -> Version {
         self.reader.version()
+    }
+
+    fn reader(&self) -> &'a R {
+        self.reader
     }
 }
 

--- a/jmt/src/tree.rs
+++ b/jmt/src/tree.rs
@@ -4,7 +4,7 @@ use alloc::{format, vec};
 use core::{cmp::Ordering, convert::TryInto};
 #[cfg(not(feature = "std"))]
 use hashbrown::HashMap;
-use pmt::H256;
+use serde_hash::H256;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 

--- a/jmt/src/tree.rs
+++ b/jmt/src/tree.rs
@@ -1,4 +1,5 @@
 use crate::db::VersionedDatabase;
+use crate::JellyfishMerkleIterator;
 use alloc::{collections::BTreeMap, vec::Vec};
 use alloc::{format, vec};
 use core::{cmp::Ordering, convert::TryInto};
@@ -6,7 +7,7 @@ use core::{cmp::Ordering, convert::TryInto};
 use hashbrown::HashMap;
 use serde_hash::H256;
 #[cfg(feature = "std")]
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{bail, ensure, format_err, Context, Result};
 use sha2::Sha256;
@@ -69,6 +70,22 @@ where
     ) -> Result<()> {
         let (element_value, _) = self.get_with_proof(element_key, version)?;
         proof.verify(expected_root_hash, element_key, element_value)
+    }
+
+    fn iter(&self, version: Version, starting_key: KeyHash) -> Result<JellyfishMerkleIterator<R>> {
+        JellyfishMerkleIterator::new(Arc::new(self.reader.clone()), version, starting_key)
+    }
+
+    fn len(&self) -> usize {
+        self.reader.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.reader.is_empty()
+    }
+
+    fn version(&self) -> Version {
+        self.reader.version()
     }
 }
 

--- a/jmt/src/tree_cache.rs
+++ b/jmt/src/tree_cache.rs
@@ -66,7 +66,7 @@
 //! Updating node could be operated as deletion of the node followed by insertion of the updated
 //! node.
 
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::{collections::BTreeSet, sync::Arc, vec::Vec};
 #[cfg(not(feature = "std"))]
 use hashbrown::{hash_map::Entry, HashMap, HashSet};
 #[cfg(feature = "std")]
@@ -151,7 +151,7 @@ where
     R: 'a + TreeReader,
 {
     /// Constructs a new `TreeCache` instance.
-    pub fn new(reader: &'a R, next_version: Version) -> Result<Self> {
+    pub fn new(reader: &'a Arc<R>, next_version: Version) -> Result<Self> {
         let mut node_cache = HashMap::new();
         let root_node_key = if next_version == 0 {
             let pre_genesis_root_key = NodeKey::new_empty_path(PRE_GENESIS_VERSION);

--- a/jmt/src/trie.rs
+++ b/jmt/src/trie.rs
@@ -1,6 +1,6 @@
 use crate::{
-    db::VersionedDatabase, proof::SparseMerkleProof, storage::TreeReader, KeyHash, OwnedValue,
-    RootHash, SimpleHasher, Version,
+    db::VersionedDatabase, proof::SparseMerkleProof, storage::TreeReader, JellyfishMerkleIterator,
+    KeyHash, OwnedValue, RootHash, SimpleHasher, Version,
 };
 use anyhow::Result;
 
@@ -33,4 +33,18 @@ where
         expected_root_hash: RootHash,
         proof: SparseMerkleProof<H>,
     ) -> Result<()>;
+
+    /// Create a [`JellyfishMerkleIterator`] from the reader: R, to iterate
+    /// over values in the tree starting at the given key and version.
+    fn iter(&self, version: Version, starting_key: KeyHash) -> Result<JellyfishMerkleIterator<R>>;
+
+    /// Get the number of `Some(value)`s from the latest version of the tree stored in the `VersionedDatabase`.
+    fn len(&self) -> usize;
+
+    /// Returns true if there are no nodes with `OwnedValue`s for the latest
+    /// `Version` in `VersionedDatabase::value_history()`
+    fn is_empty(&self) -> bool;
+
+    /// Get the latest [`Version`] of the tree from the tree store's value history.
+    fn version(&self) -> Version;
 }

--- a/jmt/src/trie.rs
+++ b/jmt/src/trie.rs
@@ -5,7 +5,7 @@ use crate::{
 use anyhow::Result;
 
 /// Exposes additional convenience methods for the [`JellyfishMerkleTree`](./jmt/tree).
-pub trait VersionedTrie<R, H>
+pub trait VersionedTrie<'a, R, H>
 where
     R: TreeReader + VersionedDatabase,
     H: SimpleHasher,
@@ -47,4 +47,6 @@ where
 
     /// Get the latest [`Version`] of the tree from the tree store's value history.
     fn version(&self) -> Version;
+
+    fn reader(&self) -> &'a R;
 }

--- a/jmt/src/trie.rs
+++ b/jmt/src/trie.rs
@@ -49,5 +49,7 @@ where
     /// Get the latest [`Version`] of the tree from the tree store's value history.
     fn version(&self) -> Version;
 
+    /// Returns a reference to the reader for use in updating
+    /// the database.
     fn reader(&self) -> &Arc<R>;
 }

--- a/jmt/src/trie.rs
+++ b/jmt/src/trie.rs
@@ -2,10 +2,11 @@ use crate::{
     db::VersionedDatabase, proof::SparseMerkleProof, storage::TreeReader, JellyfishMerkleIterator,
     KeyHash, OwnedValue, RootHash, SimpleHasher, Version,
 };
+use alloc::sync::Arc;
 use anyhow::Result;
 
 /// Exposes additional convenience methods for the [`JellyfishMerkleTree`](./jmt/tree).
-pub trait VersionedTrie<'a, R, H>
+pub trait VersionedTrie<R, H>
 where
     R: TreeReader + VersionedDatabase,
     H: SimpleHasher,
@@ -48,5 +49,5 @@ where
     /// Get the latest [`Version`] of the tree from the tree store's value history.
     fn version(&self) -> Version;
 
-    fn reader(&self) -> &'a R;
+    fn reader(&self) -> &Arc<R>;
 }

--- a/pmt/Cargo.toml
+++ b/pmt/Cargo.toml
@@ -9,6 +9,8 @@ authors = ["VRRB Labs <info@vrrb.io>"]
 name = "pmt"
 
 [dependencies]
+serde_hash = { workspace = true }
+jmt = { workspace = true }
 left-right = { workspace = true }
 hashbrown = { workspace = true }
 keccak-hash = { workspace = true }

--- a/pmt/src/error.rs
+++ b/pmt/src/error.rs
@@ -1,7 +1,8 @@
 use rlp::DecoderError;
+use serde_hash::H256;
 use thiserror::Error;
 
-use crate::{nibbles::Nibbles, node::NodeError, serde_hash::H256};
+use crate::{nibbles::Nibbles, node::NodeError};
 
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum TrieError {

--- a/pmt/src/inner.rs
+++ b/pmt/src/inner.rs
@@ -8,6 +8,7 @@ use std::{borrow::BorrowMut, fmt::Display};
 use hashbrown::{HashMap, HashSet};
 use rlp::{Prototype, Rlp, RlpStream};
 use serde::{Deserialize, Serialize};
+use serde_hash::{keccak, H256};
 
 use crate::{
     common::{Key, OwnedValue, Value},
@@ -16,7 +17,6 @@ use crate::{
     nibbles::Nibbles,
     node::{BranchNode, ExtensionNode, HashNode, Node},
     result::Result,
-    serde_hash::{keccak, H256},
     trie::Trie,
     TrieIterator,
 };

--- a/pmt/src/lib.rs
+++ b/pmt/src/lib.rs
@@ -20,8 +20,9 @@ pub(crate) mod nibbles;
 pub(crate) mod node;
 
 pub use jmt::{
-    db::VersionedDatabase, mock::MockTreeStore, reader::TreeReader, trie::VersionedTrie, H256Jmt,
-    JellyfishMerkleIterator, JellyfishMerkleTree, KeyHash, OwnedValue, SimpleHasher, Version,
+    db::VersionedDatabase, mock::MockTreeStore, proof::SparseMerkleProof, reader::TreeReader,
+    trie::VersionedTrie, H256Jmt, JellyfishMerkleIterator, JellyfishMerkleTree, KeyHash,
+    OwnedValue, RootHash, Sha256, SimpleHasher, ValueHash, Version,
 };
 pub use serde_hash::H256;
 

--- a/pmt/src/lib.rs
+++ b/pmt/src/lib.rs
@@ -8,7 +8,6 @@ pub mod trie;
 pub mod trie_iterator;
 
 pub mod common;
-pub mod serde_hash;
 pub use common::*;
 pub use db::*;
 pub use error::*;
@@ -20,6 +19,7 @@ pub use trie_iterator::*;
 pub(crate) mod nibbles;
 pub(crate) mod node;
 
+pub use jmt::{db::VersionedDatabase, trie::VersionedTrie};
 pub use serde_hash::H256;
 
 #[cfg(test)]

--- a/pmt/src/lib.rs
+++ b/pmt/src/lib.rs
@@ -21,8 +21,8 @@ pub(crate) mod node;
 
 pub use jmt::{
     db::VersionedDatabase, mock::MockTreeStore, proof::SparseMerkleProof, reader::TreeReader,
-    trie::VersionedTrie, H256Jmt, JellyfishMerkleIterator, JellyfishMerkleTree, KeyHash,
-    OwnedValue, RootHash, Sha256, SimpleHasher, ValueHash, Version,
+    trie::VersionedTrie, writer::TreeWriter, H256Jmt, JellyfishMerkleIterator, JellyfishMerkleTree,
+    KeyHash, OwnedValue, RootHash, Sha256, SimpleHasher, ValueHash, Version,
 };
 pub use serde_hash::H256;
 

--- a/pmt/src/lib.rs
+++ b/pmt/src/lib.rs
@@ -30,12 +30,12 @@ mod tests {
     };
 
     use rand::{distributions::Alphanumeric, seq::SliceRandom, thread_rng, Rng};
+    use serde_hash::{keccak, H256};
 
     use crate::{
         db::{Database, MemoryDB},
         error::TrieError,
         nibbles::Nibbles,
-        serde_hash::{keccak, H256},
     };
     use crate::{InnerTrie, Trie};
 

--- a/pmt/src/lib.rs
+++ b/pmt/src/lib.rs
@@ -19,7 +19,10 @@ pub use trie_iterator::*;
 pub(crate) mod nibbles;
 pub(crate) mod node;
 
-pub use jmt::{db::VersionedDatabase, trie::VersionedTrie};
+pub use jmt::{
+    db::VersionedDatabase, mock::MockTreeStore, reader::TreeReader, trie::VersionedTrie,
+    JellyfishMerkleIterator, JellyfishMerkleTree, SimpleHasher,
+};
 pub use serde_hash::H256;
 
 #[cfg(test)]

--- a/pmt/src/lib.rs
+++ b/pmt/src/lib.rs
@@ -20,8 +20,8 @@ pub(crate) mod nibbles;
 pub(crate) mod node;
 
 pub use jmt::{
-    db::VersionedDatabase, mock::MockTreeStore, reader::TreeReader, trie::VersionedTrie,
-    JellyfishMerkleIterator, JellyfishMerkleTree, SimpleHasher,
+    db::VersionedDatabase, mock::MockTreeStore, reader::TreeReader, trie::VersionedTrie, H256Jmt,
+    JellyfishMerkleIterator, JellyfishMerkleTree, KeyHash, OwnedValue, SimpleHasher, Version,
 };
 pub use serde_hash::H256;
 

--- a/pmt/src/node.rs
+++ b/pmt/src/node.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
+use serde_hash::H256;
 use thiserror::Error;
 
-use crate::{common::BRANCHING_FACTOR, nibbles::Nibbles, serde_hash::H256};
+use crate::{common::BRANCHING_FACTOR, nibbles::Nibbles};
 
 pub type Link = Box<Node>;
 

--- a/pmt/src/trie.rs
+++ b/pmt/src/trie.rs
@@ -1,7 +1,7 @@
 use crate::common::{Key, OwnedValue, Value};
 use crate::db::Database;
 use crate::result::Result;
-use crate::serde_hash::H256;
+use serde_hash::H256;
 
 #[deprecated(since = "1.0.0", note = "replaced by VersionedTrie")]
 pub trait Trie<D: Database> {

--- a/serde_hash/Cargo.toml
+++ b/serde_hash/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "serde_hash"
+description = "An adaptation of keccak_hash that implements serde's derive macros"
+version = "1.0.0"
+edition = "2021"
+authors = ["VRRB Labs <info@vrrb.io>"]
+
+[lib]
+name = "serde_hash"
+
+[dependencies]
+keccak-hash = { workspace = true }
+fixed-hash = { workspace = true }
+serde = { workspace = true }

--- a/serde_hash/src/lib.rs
+++ b/serde_hash/src/lib.rs
@@ -17,8 +17,8 @@ construct_fixed_hash! {
 
 /// An adaptation of the `keccak_hash::keccak` function that returns
 /// a [serde_hash::H256].
-pub fn keccak<T: AsRef<[u8]>>(s: T) -> crate::serde_hash::H256 {
+pub fn keccak<T: AsRef<[u8]>>(s: T) -> H256 {
     let mut result = [0u8; 32];
     write_keccak(s, &mut result);
-    crate::serde_hash::H256(result)
+    H256(result)
 }


### PR DESCRIPTION
Closes #18 
Closes #19 
Closes #20 

Adds a tree reader method to access storage from the tree & makes the `jmt` api available to `lr_trie`.