### PR TITLE
Add associated types to VersionedDatabase

### DIFF
--- a/jmt/src/tree.rs
+++ b/jmt/src/tree.rs
@@ -96,7 +96,7 @@ where
     }
 
     fn version(&self) -> Version {
-        self.reader.version()
+        self.reader.version().into()
     }
 
     fn reader(&self) -> &Arc<R> {


### PR DESCRIPTION
Adds associated types to VersionedDatabase so that it can be applied to structs with different configurations and different types can be expected.