### PR TITLE
Reverted some associated types that were overkill and breaking stuff, kept others

### DIFF
--- a/jmt/src/iterator.rs
+++ b/jmt/src/iterator.rs
@@ -296,7 +296,7 @@ where
                     self.done = true;
                     return match self
                         .reader
-                        .get_value(root_node_key.version(), leaf_node.key_hash())
+                        .get_value(root_node_key.version().into(), leaf_node.key_hash())
                     {
                         Ok(value) => Some(Ok((leaf_node.key_hash(), value))),
                         Err(e) => Some(Err(e)),
@@ -335,7 +335,7 @@ where
                 Ok(Node::Leaf(leaf_node)) => {
                     return match self
                         .reader
-                        .get_value(node_key.version(), leaf_node.key_hash())
+                        .get_value(node_key.version().into(), leaf_node.key_hash())
                     {
                         Ok(value) => {
                             let ret = (leaf_node.key_hash(), value);

--- a/jmt/src/reader.rs
+++ b/jmt/src/reader.rs
@@ -2,12 +2,13 @@ use alloc::vec::Vec;
 use anyhow::{format_err, Result};
 
 use crate::node_type::{LeafNode, Node, NodeKey};
-use crate::{KeyHash, OwnedValue, Version};
+use crate::{KeyHash, OwnedValue};
 
 /// Defines the interface between a
 /// [`JellyfishMerkleTree`](crate::JellyfishMerkleTree)
 /// and underlying storage holding nodes.
 pub trait TreeReader: Clone + Default {
+    type Version: Into<u64> + From<u64> + From<Vec<u8>> + Into<Vec<u8>> + Copy + Clone + Default + std::fmt::Debug + std::fmt::Display + Ord + Eq;
     /// Gets node given a node key. Returns error if the node does not exist.
     fn get_node(&self, node_key: &NodeKey) -> Result<Node> {
         self.get_node_option(node_key)?
@@ -19,7 +20,7 @@ pub trait TreeReader: Clone + Default {
 
     /// Gets a value by identifier, returning the newest value whose version is *less than or
     /// equal to* the specified version. Returns an error if the value does not exist.
-    fn get_value(&self, max_version: Version, key_hash: KeyHash) -> Result<OwnedValue> {
+    fn get_value(&self, max_version: Self::Version, key_hash: KeyHash) -> Result<OwnedValue> {
         self.get_value_option(max_version, key_hash)?
             .ok_or_else(|| {
                 format_err!(
@@ -32,7 +33,7 @@ pub trait TreeReader: Clone + Default {
     /// equal to* the specified version.  Returns None if the value does not exist.
     fn get_value_option(
         &self,
-        max_version: Version,
+        max_version: Self::Version,
         key_hash: KeyHash,
     ) -> Result<Option<OwnedValue>>;
 

--- a/jmt/src/tree.rs
+++ b/jmt/src/tree.rs
@@ -65,7 +65,7 @@ where
     H: SimpleHasher,
 {
     fn get(&self, key: KeyHash, version: Version) -> Result<Option<OwnedValue>> {
-        self.reader.get_value_option(version, key)
+        self.reader.get_value_option(version.into(), key)
     }
 
     fn get_proof(&self, key: KeyHash, version: Version) -> Result<SparseMerkleProof<H>> {
@@ -884,7 +884,7 @@ where
                 Node::Leaf(leaf_node) => {
                     return Ok((
                         if leaf_node.key_hash() == key {
-                            Some(self.reader.get_value(version, leaf_node.key_hash())?)
+                            Some(self.reader.get_value(version.into(), leaf_node.key_hash())?)
                         } else {
                             None
                         },


### PR DESCRIPTION
This PR reverts the associated types on VersionedDatabase trait for NodeKey, KeyHash and Node, keeps Version, NodeIter and HistoryIter associated types as these will be needed. May be able to remove them in future and adjust MockTreeStore but in order to ensure that it can be implemented on other types that need the trait methods, this is the best solution for now. 