### PR TITLE
Make TreeWriter method and a VersionedDatabase method take a mutable reference to self

### DIFF
--- a/jmt/src/db.rs
+++ b/jmt/src/db.rs
@@ -104,9 +104,16 @@ pub trait VersionedDatabase: Send + Sync + Clone + Default + std::fmt::Debug {
     /// }
     /// assert!(db.is_empty());
     /// ```
+    #[cfg(any(test, feature = "mocks"))]
+    fn update(&self, tree_update_batch: TreeUpdateBatch) -> Result<()> {
+        self.update_batch(tree_update_batch)
+    }
+    
+    #[cfg(not(any(test, feature = "mocks")))]
     fn update(&mut self, tree_update_batch: TreeUpdateBatch) -> Result<()> {
         self.update_batch(tree_update_batch)
     }
+    
 
     /// Wrapper around [`TreeWriter::write_node_batch`](jmt/src/writer.rs) that also updates stale nodes.
     ///
@@ -114,8 +121,12 @@ pub trait VersionedDatabase: Send + Sync + Clone + Default + std::fmt::Debug {
     ///
     /// See [`jmt::tests::jellyfish_merkle::test_batch_insertion`](jmt/src/tests/jellyfish_merkle.rs)
     /// for a detailed example.
-    fn update_batch(&mut self, tree_update_batch: TreeUpdateBatch) -> Result<()>;
+    #[cfg(any(test, feature = "mocks"))]
+    fn update_batch(&self, tree_update_batch: TreeUpdateBatch) -> Result<()>;
 
+    #[cfg(not(any(test, feature = "mocks")))]
+    fn update_batch(&mut self, tree_update_batch: TreeUpdateBatch) -> Result<()>;
+    
     /// Returns the number of `Some` values within `value_history`
     /// for all keys at the latest version.
     ///

--- a/jmt/src/db.rs
+++ b/jmt/src/db.rs
@@ -104,7 +104,7 @@ pub trait VersionedDatabase: Send + Sync + Clone + Default + std::fmt::Debug {
     /// }
     /// assert!(db.is_empty());
     /// ```
-    fn update(&self, tree_update_batch: TreeUpdateBatch) -> Result<()> {
+    fn update(&mut self, tree_update_batch: TreeUpdateBatch) -> Result<()> {
         self.update_batch(tree_update_batch)
     }
 
@@ -114,7 +114,7 @@ pub trait VersionedDatabase: Send + Sync + Clone + Default + std::fmt::Debug {
     ///
     /// See [`jmt::tests::jellyfish_merkle::test_batch_insertion`](jmt/src/tests/jellyfish_merkle.rs)
     /// for a detailed example.
-    fn update_batch(&self, tree_update_batch: TreeUpdateBatch) -> Result<()>;
+    fn update_batch(&mut self, tree_update_batch: TreeUpdateBatch) -> Result<()>;
 
     /// Returns the number of `Some` values within `value_history`
     /// for all keys at the latest version.

--- a/jmt/src/mock.rs
+++ b/jmt/src/mock.rs
@@ -66,7 +66,7 @@ impl VersionedDatabase for MockTreeStore {
         self.get_value_option(max_version, key_hash)
     }
 
-    fn update_batch(&self, tree_update_batch: TreeUpdateBatch) -> Result<()> {
+    fn update_batch(&mut self, tree_update_batch: TreeUpdateBatch) -> Result<()> {
         self.write_tree_update_batch(tree_update_batch)
     }
 
@@ -130,7 +130,7 @@ impl HasPreimage for MockTreeStore {
 }
 
 impl TreeWriter for MockTreeStore {
-    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
+    fn write_node_batch(&mut self, node_batch: &NodeBatch) -> Result<()> {
         let mut locked = self.data.write();
         for (node_key, node) in node_batch.nodes() {
             let replaced = locked.nodes.insert(node_key.clone(), node.clone());
@@ -214,8 +214,8 @@ impl MockTreeStore {
         Ok(())
     }
 
-    pub fn write_tree_update_batch(&self, batch: TreeUpdateBatch) -> Result<()> {
-        self.write_node_batch(&batch.node_batch)?;
+    pub fn write_tree_update_batch(&mut self, batch: TreeUpdateBatch) -> Result<()> {
+        self.write_node_batch(&mut batch.node_batch)?;
         batch
             .stale_node_index_batch
             .into_iter()

--- a/jmt/src/mock.rs
+++ b/jmt/src/mock.rs
@@ -66,7 +66,8 @@ impl VersionedDatabase for MockTreeStore {
         self.get_value_option(max_version, key_hash)
     }
 
-    fn update_batch(&mut self, tree_update_batch: TreeUpdateBatch) -> Result<()> {
+    #[cfg(any(test, feature = "mocks"))]
+    fn update_batch(&self, tree_update_batch: TreeUpdateBatch) -> Result<()> {
         self.write_tree_update_batch(tree_update_batch)
     }
 
@@ -130,7 +131,7 @@ impl HasPreimage for MockTreeStore {
 }
 
 impl TreeWriter for MockTreeStore {
-    fn write_node_batch(&mut self, node_batch: &NodeBatch) -> Result<()> {
+    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()> {
         let mut locked = self.data.write();
         for (node_key, node) in node_batch.nodes() {
             let replaced = locked.nodes.insert(node_key.clone(), node.clone());
@@ -214,8 +215,8 @@ impl MockTreeStore {
         Ok(())
     }
 
-    pub fn write_tree_update_batch(&mut self, batch: TreeUpdateBatch) -> Result<()> {
-        self.write_node_batch(&mut batch.node_batch)?;
+    pub fn write_tree_update_batch(&self, batch: TreeUpdateBatch) -> Result<()> {
+        self.write_node_batch(&batch.node_batch)?;
         batch
             .stale_node_index_batch
             .into_iter()

--- a/jmt/src/writer.rs
+++ b/jmt/src/writer.rs
@@ -17,6 +17,10 @@ use crate::{
 /// to the underlying storage holding nodes.
 pub trait TreeWriter {
     /// Writes a node batch into storage.
+    #[cfg(any(test, feature = "mocks"))]
+    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()>;
+
+    #[cfg(not(any(test, feature = "mocks")))]
     fn write_node_batch(&mut self, node_batch: &NodeBatch) -> Result<()>;
 }
 

--- a/jmt/src/writer.rs
+++ b/jmt/src/writer.rs
@@ -17,7 +17,7 @@ use crate::{
 /// to the underlying storage holding nodes.
 pub trait TreeWriter {
     /// Writes a node batch into storage.
-    fn write_node_batch(&self, node_batch: &NodeBatch) -> Result<()>;
+    fn write_node_batch(&mut self, node_batch: &NodeBatch) -> Result<()>;
 }
 
 /// Node batch that will be written into db atomically with other batches.


### PR DESCRIPTION
These traits need to be implemented on types that are not behind `Arc<RwLock<T>>`