### PR TITLE
Add helper methods and utils

### DIFF
--- a/jmt/Cargo.toml
+++ b/jmt/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true }
 ics23 = { version = "0.10.0", optional = true }
 parking_lot = { version = "0.12.1", optional = true }
 thiserror = { version = "1.0.32", optional = true }
+bincode = "1.3.3"
 
 [dev-dependencies]
 hex = { workspace = true }

--- a/jmt/src/iterator.rs
+++ b/jmt/src/iterator.rs
@@ -99,6 +99,7 @@ impl NodeVisitInfo {
 /// key-value pairs in this version of the tree, starting from the smallest key
 /// that is greater or equal to the given key, by performing a depth first
 /// traversal on the tree.
+#[derive(Debug)]
 pub struct JellyfishMerkleIterator<R: TreeReader + VersionedDatabase> {
     /// The storage engine from which we can read nodes using node keys.
     reader: Arc<R>,

--- a/jmt/src/lib.rs
+++ b/jmt/src/lib.rs
@@ -181,6 +181,12 @@ pub struct RootHash(pub [u8; 32]);
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 pub struct KeyHash(pub [u8; 32]);
 
+impl KeyHash {
+    pub fn sha256<K: Default + serde::Serialize>() -> Self {
+        Self::with::<Sha256>(bincode::serialize(&K::default()).unwrap_or_default())
+    }
+}
+
 #[derive(
     Copy,
     Clone,

--- a/jmt/src/tree.rs
+++ b/jmt/src/tree.rs
@@ -83,8 +83,8 @@ where
         proof.verify(expected_root_hash, element_key, element_value)
     }
 
-    fn iter(&self, version: Version, starting_key: KeyHash) -> Result<JellyfishMerkleIterator<R>> {
-        JellyfishMerkleIterator::new(Arc::clone(&self.reader), version, starting_key)
+    fn iter(&self, version: Version) -> Result<JellyfishMerkleIterator<R>> {
+        JellyfishMerkleIterator::new_by_index(Arc::clone(&self.reader), version, 0)
     }
 
     fn len(&self) -> usize {
@@ -884,7 +884,10 @@ where
                 Node::Leaf(leaf_node) => {
                     return Ok((
                         if leaf_node.key_hash() == key {
-                            Some(self.reader.get_value(version.into(), leaf_node.key_hash())?)
+                            Some(
+                                self.reader
+                                    .get_value(version.into(), leaf_node.key_hash())?,
+                            )
                         } else {
                             None
                         },

--- a/jmt/src/trie.rs
+++ b/jmt/src/trie.rs
@@ -37,7 +37,7 @@ where
 
     /// Create a [`JellyfishMerkleIterator`] from the reader: R, to iterate
     /// over values in the tree starting at the given key and version.
-    fn iter(&self, version: Version, starting_key: KeyHash) -> Result<JellyfishMerkleIterator<R>>;
+    fn iter(&self, version: Version) -> Result<JellyfishMerkleIterator<R>>;
 
     /// Get the number of `Some(value)`s from the latest version of the tree stored in the `VersionedDatabase`.
     fn len(&self) -> usize;


### PR DESCRIPTION
Adds some utility needed for storage tests in both `integral_db` & the protocol codebase's storage crate

The most notable change here is how we create the iterator from the tree.